### PR TITLE
supported more function component usages

### DIFF
--- a/src/AddReactHotLoaderToSource.js
+++ b/src/AddReactHotLoaderToSource.js
@@ -48,7 +48,7 @@ function getExportDefaultClassName(source) {
 
 function getExportDefaultFunctionName(source) {
     let functionName = '';
-    const matches = source.match(/^\s*export\s+default\s+function\s+(.*?)\s+/m);
+    const matches = source.match(/^\s*export\s+default\s+function\s+([^(\s]*)\s?\(/m);
     if (matches && matches[1]) {
         functionName = matches[1];
     }

--- a/test/exampleFiles.js
+++ b/test/exampleFiles.js
@@ -105,6 +105,44 @@ const reactAppToMakeSuperHot = class extends Component {
 }
 export default hot(module)(reactAppToMakeSuperHot);`;
 
+// Case 10
+const functionalComponentNoSpacing = `export default function exportedFunction() {
+    return 'whatever';
+}`;
+const expectedFunctionalComponentNoSpacing = `import {hot} from 'react-hot-loader';
+function exportedFunction() {
+    return 'whatever';
+}
+export default hot(module)(exportedFunction);`;
+
+const functionalComponentWithParams = `export default function exportedFunction({ name }) {
+    return 'whatever';
+}`;
+const expectedFunctionalComponentWithParams = `import {hot} from 'react-hot-loader';
+function exportedFunction({ name }) {
+    return 'whatever';
+}
+export default hot(module)(exportedFunction);`;
+
+const functionalComponentNoName = `export default function () {
+    return 'whatever';
+}`;
+const expectedFunctionalComponentNoName = `import {hot} from 'react-hot-loader';
+const reactAppToMakeSuperHot = function () {
+    return 'whatever';
+}
+export default hot(module)(reactAppToMakeSuperHot);`;
+
+const functionalComponentNoNameAndNoSpace = `export default function() {
+    return 'whatever';
+}`;
+const expectedFunctionalComponentNoNameAndNoSpace = `import {hot} from 'react-hot-loader';
+const reactAppToMakeSuperHot = function() {
+    return 'whatever';
+}
+export default hot(module)(reactAppToMakeSuperHot);`;
+
+
 const exampleFiles = {
     emptyFile,
     fileWithoutAnyExport,
@@ -115,6 +153,10 @@ const exampleFiles = {
     arrowFunction,
     wrappedWithHOC,
     exportAnonymousClass,
+    functionalComponentNoSpacing,
+    functionalComponentWithParams,
+    functionalComponentNoName,
+    functionalComponentNoNameAndNoSpace,
 };
 
 const expectedOutputFiles = {
@@ -127,6 +169,10 @@ const expectedOutputFiles = {
     arrowFunction: expectedArrowFunction,
     wrappedWithHOC: expectedWrappedWithHOC,
     exportAnonymousClass: expectedExportAnonymousClass,
+    functionalComponentNoSpacing: expectedFunctionalComponentNoSpacing,
+    functionalComponentWithParams: expectedFunctionalComponentWithParams,
+    functionalComponentNoName: expectedFunctionalComponentNoName,
+    functionalComponentNoNameAndNoSpace: expectedFunctionalComponentNoNameAndNoSpace,
 };
 
 module.exports = {exampleFiles, expectedOutputFiles};

--- a/test/exampleFiles.js
+++ b/test/exampleFiles.js
@@ -115,6 +115,7 @@ function exportedFunction() {
 }
 export default hot(module)(exportedFunction);`;
 
+// Case 11
 const functionalComponentWithParams = `export default function exportedFunction({ name }) {
     return 'whatever';
 }`;
@@ -124,6 +125,7 @@ function exportedFunction({ name }) {
 }
 export default hot(module)(exportedFunction);`;
 
+// Case 12
 const functionalComponentNoName = `export default function () {
     return 'whatever';
 }`;
@@ -133,6 +135,7 @@ const reactAppToMakeSuperHot = function () {
 }
 export default hot(module)(reactAppToMakeSuperHot);`;
 
+// Case 13
 const functionalComponentNoNameAndNoSpace = `export default function() {
     return 'whatever';
 }`;


### PR DESCRIPTION
supported before function component usages:
- `export default function ()`, without function name，but there's a space before ().
- `export default function exportedFunction()`， there's no space before ().