### PR TITLE
Do nothing if NODE_ENV=production

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Webpack Loader that automatically inserts react-hot-loader to your app, **without any changes in your app code**.
 
-All it takes is a simple regex to indicate where your "App" Components are.
+All it takes is a simple regex to indicate where your "App" Components are. This module does nothing if `NODE_ENV` is set to `production`.
 
 Example:
 

--- a/src/AddReactHotLoaderToSource.js
+++ b/src/AddReactHotLoaderToSource.js
@@ -1,5 +1,5 @@
 function AddReactHotLoader(source) {
-    if (!source || !/^\s*export\s+default/m.exec(source)) {
+    if (process.env.NODE_ENV === 'production' || !source || !/^\s*export\s+default/m.exec(source)) {
         return source;
     }
     let newSource = getImportLine() + source;

--- a/test/AddReactHotLoaderToSource.test.js
+++ b/test/AddReactHotLoaderToSource.test.js
@@ -1,10 +1,26 @@
-const AddReactHotLoaderToSource = require('../src/AddReactHotLoaderToSource');
 const {exampleFiles, expectedOutputFiles} = require('./exampleFiles');
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+beforeEach(() => {
+    jest.resetModules();
+});
 
 describe('AddReactHotLoaderToSource', () => {
     Object.keys(exampleFiles).forEach(f => {
         it(`should match expected file for ${f}`, () => {
+            process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+            const AddReactHotLoaderToSource = require('../src/AddReactHotLoaderToSource');
             expect(AddReactHotLoaderToSource(exampleFiles[f])).toBe(expectedOutputFiles[f]);
+        });
+    });
+})
+
+describe('AddReactHotLoaderToSource with NODE_ENV=production', () => {
+    Object.keys(exampleFiles).forEach(f => {
+        it(`should not modify file ${f}`, () => {
+            process.env.NODE_ENV = 'production';
+            const AddReactHotLoaderToSource = require('../src/AddReactHotLoaderToSource');
+            expect(AddReactHotLoaderToSource(exampleFiles[f])).toBe(exampleFiles[f]);
         });
     });
 });


### PR DESCRIPTION
First of all this module is great, thanks for your effort 👍 

Similar to `react-hot-loader`, this module should do nothing in production mode. 

Applying loaders only in dev-specific builds is rather tedious and leads to implementations such as:

```js
config.module.rules = config.module.rules.map((rule) => {
  if (String(rule.test) !== String(/\.jsx?$/)) {
    return rule
  }

  return {
    ...rule,
    use: [...rule.use, { loader: require.resolve('react-hot-loader-loader') }]
  }
})
```

This PR checks whether `NODE_ENV` is set to `production` and returns the source without applying any transforms.

